### PR TITLE
Allow domain overrides for challenge delegation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ duckdns [<api_token>] {
 }
 ```
 
-`api_token` may be specified as an argument to the `duckdns` directive, or in the body.
-`override_domain` is optional; see "Challenge delegation" below.
+- `api_token` may be specified as an argument to the `duckdns` directive, or in the body.
+- `override_domain` is optional; see "Challenge delegation" below.
 
 ## Config examples
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,18 @@ This package contains a DNS provider module for [Caddy](https://github.com/caddy
 dns.providers.duckdns
 ```
 
+## Caddyfile definition
+
+```
+duckdns [<api_token>] {
+    api_token <api_token>
+    override_domain <duckdns_domain>
+}
+```
+
+`api_token` may be specified as an argument to the `duckdns` directive, or in the body.
+`override_domain` is optional; see "Challenge delegation" below.
+
 ## Config examples
 
 To use this module for the ACME DNS challenge, [configure the ACME issuer in your Caddy JSON](https://caddyserver.com/docs/json/apps/tls/automation/policies/issuer/acme/) like so:
@@ -20,7 +32,8 @@ To use this module for the ACME DNS challenge, [configure the ACME issuer in you
 		"dns": {
 			"provider": {
 				"name": "duckdns",
-				"api_token": "YOUR_DUCKDNS_API_TOKEN"
+				"api_token": "YOUR_DUCKDNS_API_TOKEN",
+				"override_domain": "OPTIONAL_DUCKDNS_DOMAIN"
 			}
 		}
 	}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ duckdns [<api_token>] {
 ```
 
 - `api_token` may be specified as an argument to the `duckdns` directive, or in the body.
-- `override_domain` is optional; see "Challenge delegation" below.
+- `override_domain` is optional; see [Challenge delegation](#challenge-delegation) below.
 
 ## Config examples
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ dns.providers.duckdns
 
 To use this module for the ACME DNS challenge, [configure the ACME issuer in your Caddy JSON](https://caddyserver.com/docs/json/apps/tls/automation/policies/issuer/acme/) like so:
 
-```
+```json
 {
 	"module": "acme",
 	"challenges": {
@@ -31,7 +31,7 @@ or with the Caddyfile:
 
 ```
 tls {
-	dns cloudflare {env.DUCKDNS_API_TOKEN}
+	dns duckdns {env.DUCKDNS_API_TOKEN}
 }
 ```
 
@@ -41,3 +41,29 @@ You can replace `{env.DUCKDNS_API_TOKEN}` with the actual auth token if you pref
 ## Authenticating
 
 See [the associated README in the libdns package](https://github.com/libdns/duckdns) for important information about credentials. Your token can be found at the top of the page when logged in at https://www.duckdns.org.
+
+## Challenge delegation
+
+To obtain a certificate using ACME DNS challenges, you'd use this module as described above. But, if you have a different domain (say, `my.example.com`) CNAME'd to your Duck DNS domain, you have two options:
+
+1. Not use this module: Use a module matching the DNS provider for `my.example.com`.
+2. [Delegate the challenge](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge) to Duck DNS.
+
+Delegating the challenge is actually quite easy, and may be useful if the DNS provider for `my.example.com` is difficult to configure or slow:
+
+> Since Let’s Encrypt follows the DNS standards when looking up TXT records for DNS-01 validation, you can use CNAME records or NS records to delegate answering the challenge to other DNS zones. This can be used to delegate the _acme-challenge subdomain to a validation-specific server or zone. It can also be used if your DNS provider is slow to update, and you want to delegate to a quicker-updating server.
+
+Let's say you have `my.example.com` as a CNAME to `example.duckdns.org`. Following the above instructions, you'd want to add a CNAME from `_acme-challenge.my.example.com` to `example.duckdns.org`. Then, in your Caddyfile, instruct this module to override the domain used when communicating with Duck DNS' API:
+
+```
+my.example.com {
+	tls {
+		dns duckdns <token> {
+			override_domain example.duckdns.org
+		}
+	}
+	...
+}
+```
+
+If you do not set `override_domain`, this module will attempt to ask Duck DNS to update `my.example.com`. Duck DNS will return an error, because it does not know about `my.example.com`. Setting this value fixes this up and allows Caddy to ask for a certificate matching `my.example.com`, but by performing DNS challenges on `example.duckdns.org` instead!

--- a/duckdns.go
+++ b/duckdns.go
@@ -25,6 +25,7 @@ func (Provider) CaddyModule() caddy.ModuleInfo {
 //
 // duckdns [<api_token>] {
 //     api_token <api_token>
+//     override_domain <duckdns_domain>
 // }
 //
 func (p *Provider) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
@@ -39,10 +40,24 @@ func (p *Provider) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		for nesting := d.Nesting(); d.NextBlock(nesting); {
 			switch d.Val() {
 			case "api_token":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
 				if p.Provider.APIToken != "" {
 					return d.Err("API token already set")
 				}
 				p.Provider.APIToken = repl.ReplaceAll(d.Val(), "")
+				if d.NextArg() {
+					return d.ArgErr()
+				}
+			case "override_domain":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+				if p.Provider.OverrideDomain != "" {
+					return d.Err("Override domain already set")
+				}
+				p.Provider.OverrideDomain = repl.ReplaceAll(d.Val(), "")
 				if d.NextArg() {
 					return d.ArgErr()
 				}


### PR DESCRIPTION
For more information, see https://github.com/libdns/duckdns/pull/1

This commit adds Caddyfile parsing for an `override_domain`
directive.

---

Should be pretty straightforward -- this adds `override_domain` in the same manner as `api_token` was being parsed. I did not add it as an argument to the main directive as I don't think it'll be as commonly used.

I also changed the parsing for `api_token` -- unless I missed something, I think this wasn't working. That `NextArg` call has to happen to get the parser to move on from `api_token` to the provided value.

Currently writing up a description of this in the README; I'll un-mark draft status once I have that up.